### PR TITLE
Add ModalTrace to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,8 @@ Distributions and vendors who natively support OpenTelemetry in their commercial
 ## Tools 
 - [BindPlane OP](https://github.com/observIQ/bindplane-op) - open source observability pipeline that gives you the ability to collect, refine, and ship metrics, logs, and traces to any destination.
 - [Trace Test](https://github.com/kubeshop/tracetest) - End-to-end Tests Powered by  Your OpenTelemetry Traces.
-- [Vector](https://github.com/vectordotdev/vector) - A lightweight, ultra-fast tool for building observability pipelines by Datadog. 
+- [ModalTrace](https://github.com/arnabdeypolimi/video_ai_telemetry) - OpenTelemetry-based observability SDK for real-time AI video pipelines — frame-level metrics, GPU monitoring per pipeline stage, and A/V sync drift tracking.
+- [Vector](https://github.com/vectordotdev/vector) - A lightweight, ultra-fast tool for building observability pipelines by Datadog.
 
 ## Books 📚
 


### PR DESCRIPTION
## What

Adds [ModalTrace](https://github.com/arnabdeypolimi/video_ai_telemetry) to the **Tools** section.

## Why

ModalTrace is an OpenTelemetry SDK specifically designed for real-time AI video pipelines — a domain where standard APM tools fall short. It's built directly on the OTel Python SDK and exports via OTLP.

Key capabilities:
- **Frame-level metrics** — latency, dropped frames, FPS tracked per pipeline stage (inference/render/encode)
- **A/V sync drift** — ms-level audio/video desync detection in production
- **Per-stage GPU attribution** — utilization, memory, temperature, power tied to pipeline stages
- **PyTorch auto-instrumentation** — zero-code spans for forward passes
- **Adaptive sampling** — anomaly-triggered capture for high-latency events
- **Local dashboard** — optional FastAPI + Chart.js dashboard (`pip install modaltrace[dashboard]`)
- **Any OTLP backend** — Jaeger, Grafana Tempo, Honeycomb, Datadog

Free, Apache 2.0. `pip install modaltrace`